### PR TITLE
fix: source only regular zsh include files

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -162,8 +162,8 @@ CHARSET=UTF-8
 
 unsetopt ALL_EXPORT
 
-for f in ~/.zsh-includes/*; do
-  source $f
+for f in ~/.zsh-includes/*(.N); do
+  source "$f"
 done
 
 case $TERM in


### PR DESCRIPTION
## Summary
- only iterate over regular files in the zsh include loop
- quote the sourced path to support filenames containing spaces

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9dbb77de8832fadd7c18426d41502