### PR TITLE
fix: update URL helpers to python3

### DIFF
--- a/.zsh-includes/alias-utils.zsh
+++ b/.zsh-includes/alias-utils.zsh
@@ -21,7 +21,7 @@ alias t='~/software/timebook/t'
 alias ss='~/bin/ss.sh'
 alias mksh='echo "#!/bin/sh" >>'
 #alias grep='grep --color=auto'
-alias urldecode='python -c "import sys, urllib as ul; \
-      print ul.unquote_plus(sys.argv[1])"'
-alias urlencode='python -c "import sys, urllib as ul; \
-      print ul.quote_plus(sys.argv[1])"'
+alias urldecode='python3 -c "import sys, urllib.parse as up; \
+      print(up.unquote_plus(sys.argv[1]))"'
+alias urlencode='python3 -c "import sys, urllib.parse as up; \
+      print(up.quote_plus(sys.argv[1]))"'


### PR DESCRIPTION
## Summary
- update the `urlencode` and `urldecode` aliases to invoke Python 3's urllib.parse

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9dc15e6f8832f81463f487fe7bc2a