### PR TITLE
fix: guard fzf completion sourcing

### DIFF
--- a/.zsh-includes/fzf.zsh
+++ b/.zsh-includes/fzf.zsh
@@ -14,7 +14,14 @@ export FZF_DEFAULT_OPTS='
   --color info:144,prompt:161,spinner:135,pointer:135,marker:118
 '
 
-[[ $- == *i* ]] && source "/home/kljohnso/.fzf/shell/completion.zsh" 2> /dev/null
+if [[ $- == *i* ]]; then
+  if command -v fzf >/dev/null 2>&1; then
+    fzf_completion_file="${HOME}/.fzf/shell/completion.zsh"
+    [[ -f ${fzf_completion_file} ]] && source "${fzf_completion_file}" 2>/dev/null
+  else
+    print -u2 'warning: fzf not installed; skipping fzf shell integration.'
+  fi
+fi
 
 export FZF_COMPLETION_TRIGGER=''
 for keymap in emacs viins; do


### PR DESCRIPTION
## Summary
- replace the hard-coded fzf completion path with a HOME-relative reference
- guard sourcing of the completion script and warn when fzf is unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9dc6bc72c832fbd7be9e4f932ba74