### PR TITLE
fix: ensure zsh includes glob matches symlinks

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -163,7 +163,7 @@ CHARSET=UTF-8
 unsetopt ALL_EXPORT
 autoload -U compinit; compinit
 
-for f in ~/.zsh-includes/*(.N); do
+for f in ~/.zsh-includes/*(.N) ~/.zsh-includes/*(@N); do
   source "$f"
 done
 


### PR DESCRIPTION
## Summary
- include symbolic links when sourcing files from `~/.zsh-includes` so plugins like `fzf-tab` load correctly

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9e5feb9f8832fa587292550b84025