### PR TITLE
feat: replace audible feedback with macOS notifications

### DIFF
--- a/.zsh-includes/audible-feedback.zsh
+++ b/.zsh-includes/audible-feedback.zsh
@@ -1,38 +1,94 @@
-LONG_TIME=20
-ALERT_LONG_RUN='./configure make amake cp rsync scp wget transmission aria2c'
+# macOS notification feedback for long-running or failed commands.
+#
+# This replaces the legacy speaker beep implementation, which is not
+# available on modern macOS systems. When running on macOS with the built-in
+# `osascript` utility, the shell will surface notifications for
+# long-running commands as well as failures.
 
-#alias alert_helper='history|tail -n1|sed -e "s/^\s*[0-9]\+\s*//" -e "s/;\s*alert$//" | sed -e "s/&/+/g" | sed -e "s/++ alert//g"'
-#alias alert='notify-send "Finished Job" "[$?] $(alert_helper)" && beep'
+# Guard early if notifications are not available (e.g. non-macOS systems).
+if [[ "$(uname -s)" != "Darwin" ]] || ! command -v osascript &>/dev/null; then
+  return
+fi
 
-# For measuring command duration so that long-running commands can be handled
-# differently later on (alerts, beeps, etc.)
-function preexec {
-  (( $#_elapsed > 1000 )) && set -A _elapsed $_elapsed[-100,-1]
-  typeset -ig _start=SECONDS
+# Defaults mirror the historical configuration: notify for commands in this
+# list when they exceed LONG_TIME seconds.
+: "${LONG_TIME:=20}"
+: "${ALERT_LONG_RUN:=./configure make amake cp rsync scp wget transmission aria2c}"
+
+# Track command state between hooks.
+typeset -gA _command_feedback_state
+_command_feedback_state=(
+  start_time -1
+  last_command ""
+  last_command_name ""
+)
+
+# Convert the historic space-separated string into an array for matching.
+typeset -ga _command_feedback_monitored
+_command_feedback_monitored=(${=ALERT_LONG_RUN})
+
+autoload -Uz add-zsh-hook
+add-zsh-hook -d preexec _command_feedback_preexec 2>/dev/null || true
+add-zsh-hook -d precmd _command_feedback_precmd 2>/dev/null || true
+
+# Escape strings for AppleScript.
+function _command_feedback_escape_applescript() {
+  emulate -L zsh
+  local input="$1"
+  # Escape backslashes and double quotes, and normalise newlines to spaces.
+  printf '%s' "$input" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/\n/ /g'
 }
 
-# Audible feedback on commands and long-running command handler.
-function precmd {
-  (( _start >= 0 )) && set -A _elapsed $_elapsed $(( SECONDS-_start ))
-  _start=-1
+function _command_feedback_notify() {
+  emulate -L zsh
+  local title message
+  title="$(_command_feedback_escape_applescript "$1")"
+  message="$(_command_feedback_escape_applescript "$2")"
+  osascript -e "display notification \"$message\" with title \"$title\""
+}
 
-  PREVIOUS_FULL=`history | tail -n1 | sed 's/ \+/\t/g'`
-  PREVIOUS=`echo $PREVIOUS_FULL | cut -f2`
-  PREVIOUS_FULL=`echo $PREVIOUS_FULL | cut -f2-`
+function _command_feedback_preexec() {
+  emulate -L zsh
+  _command_feedback_state[start_time]=$SECONDS
+  _command_feedback_state[last_command]="$1"
+  _command_feedback_state[last_command_name]="${1%%[[:space:]]*}"
+  if [[ -z ${_command_feedback_state[last_command_name]} ]]; then
+    _command_feedback_state[last_command_name]="$1"
+  fi
+}
 
-  if [[ $ALERT_LONG_RUN = *$PREVIOUS* ]]; then
-    if [ $_elapsed[-1] -ge $LONG_TIME ]; then
-      beep -f 880 -l 100 -d 30 -r 3
+function _command_feedback_command_tracked() {
+  emulate -L zsh
+  local candidate
+  for candidate in "${_command_feedback_monitored[@]}"; do
+    if [[ $candidate == ${_command_feedback_state[last_command_name]} ]]; then
+      return 0
     fi
+  done
+  return 1
+}
+
+function _command_feedback_precmd() {
+  local exit_code=$?
+  emulate -L zsh
+  local duration=0
+
+  if (( _command_feedback_state[start_time] >= 0 )); then
+    duration=$(( SECONDS - _command_feedback_state[start_time] ))
+  fi
+  _command_feedback_state[start_time]=-1
+
+  if (( exit_code != 0 )); then
+    _command_feedback_notify "Command failed (exit $exit_code)" \
+      "${_command_feedback_state[last_command]}"
+    return
   fi
 
-  exit_code=${?}
-  if [ $exit_code = 0 ]; then
-    #beep -f 440 -l 10
-  fi
-
-  if [ $exit_code != 0 ]; then
-    #beep -f 110 -l 100
+  if (( duration >= LONG_TIME )) && _command_feedback_command_tracked; then
+    _command_feedback_notify "Command finished" \
+      "${_command_feedback_state[last_command_name]} completed in ${duration}s"
   fi
 }
 
+add-zsh-hook preexec _command_feedback_preexec
+add-zsh-hook precmd _command_feedback_precmd


### PR DESCRIPTION
## Summary
- replace the legacy audible feedback script with macOS-native notifications driven by `osascript`
- track command lifecycle with zsh hooks to surface long-running command completions and failures

## Testing
- not run (notifications require macOS environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9ec85c350832f8f1578273e138787